### PR TITLE
Fix page not loading after restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This repository provides tools to scrape AWS exam questions and a simple fronten
 
 2. Clean or modify the JSON with the helper scripts in `scripts/` if needed.
 
-3. Open `web/index.html` in a browser to use the quiz interface.
+3. Serve the project or open the main page in a browser:
+   - You can simply open `index.html` from the repository root, which
+     redirects to the `web/` folder.
+   - Alternatively open `web/index.html` directly.
 
 ## Architecture
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=web/index.html">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>If you are not redirected automatically, <a href="web/index.html">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add root-level `index.html` that redirects to `web/index.html`
- update README instructions so users can open the new entry point easily

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686226ce00c08320928de518d5fceed4